### PR TITLE
MessageFactory, message_renderer, bot_socket, RoomItemFactory 생성 및 수정

### DIFF
--- a/app/services/MessageFactory.js
+++ b/app/services/MessageFactory.js
@@ -31,6 +31,7 @@ MessageFactory.prototype.createMyMessageRow = function (document) {
 };
 
 MessageFactory.prototype.prepareMyMessageRow = (messageRow,message,image)=>{
+  messageRow.message_row.id = message._id;
   messageRow.message_row.className = 'my-message-block';
   messageRow.message_info_row.className = 'my-message-block-info';
   messageRow.message_info_nick.innerText = message.author.nickName;
@@ -46,6 +47,7 @@ MessageFactory.prototype.prepareMyMessageRow = (messageRow,message,image)=>{
   return messageRow;
 };
 MessageFactory.prototype.prepareAnotherMessageRow = (messageRow,message,image)=>{
+  messageRow.message_row.id = message._id;
   messageRow.message_row.className = 'another-message-block';
   messageRow.message_info_row.className = 'another-message-block-info';
   messageRow.message_info_nick.innerText = message.author.nickName;

--- a/app/services/RoomItemFactory.js
+++ b/app/services/RoomItemFactory.js
@@ -1,0 +1,31 @@
+'use strict';
+
+'use strict';
+
+function RoomItemFactory() {
+  if(!(this instanceof RoomItemFactory)){
+    throw new TypeError('RoomItemFactory must be created with new keyword');
+  }
+}
+
+RoomItemFactory.prototype.createRoomItem = function (document) {
+  return {
+    room_item_text_p : document.createElement('p'),
+    room_item_div : document.createElement('div')
+  };
+};
+RoomItemFactory.prototype.prepareRoomItem = (roomItem,room)=>{
+  roomItem.room_item_text_p.innerText = room.roomName;
+  roomItem.room_item_text_p.id = room._id;
+  roomItem.room_item_div.className = 'room-item';
+  roomItem.room_item_div.id=room._id;
+  return roomItem;
+};
+
+RoomItemFactory.prototype.render = (roomItem)=>{
+  roomItem.room_item_div.appendChild(roomItem.room_item_text_p);
+  return roomItem;
+};
+
+
+module.exports = RoomItemFactory;

--- a/app/services/bot_socket.js
+++ b/app/services/bot_socket.js
@@ -19,10 +19,11 @@ function connectToBot(args, token, url, renderer) {
   });
   socket.on('news-bot',(message)=>{
     console.log(message);
-    renderer.renderMessage(message.createdMessage,renderer.messageType.ANOTHER_MESSAGE,socket.id);
+    //renderer.renderMessage(message.createdMessage,renderer.messageType.ANOTHER_MESSAGE,socket.id);
   });
   socket.on('message-public', function (message) {
-    renderer.renderMessage(message.createdMessage,renderer.messageType.ANOTHER_MESSAGE,socket.id);
+    console.log(message);
+    //renderer.renderMessage(message.createdMessage,renderer.messageType.ANOTHER_MESSAGE,socket.id);
   });
   return socket;
 };

--- a/app/services/default_socket.js
+++ b/app/services/default_socket.js
@@ -51,7 +51,9 @@ function connectToDefault(args,token,url,renderer) {
   // 방 로드 -> 해당 방 메세지 로드
   socket.on('message-get-in-room-success',(room)=>{
     console.log(room);
-    renderer.loadMessage(socket,room.messages);
+    renderer.loadMessage(socket,room.messages)
+      .then(renderer.agoLoadMessageIsResolve)
+      .catch(renderer.agoLoadMessageIsReject);
   });
 
   socket.on('message-get-in-room-fail',(e)=>{


### PR DESCRIPTION
### MessageFactory

- prepareMyMessageRow, prepareAnotherMessageRow 에서 생성하는 my-message-block 클래스를 가지는 div에 message의 오브젝트 id를 id값으로 세팅

### defalut_socket

- message-get-in-room-success 이벤트 콜백에서 renderer.loadMessage 함수 호출 부분을 MessageRenderer 의 loadMessage 함수를 비동기 프로미스로 변경함에 따라 호출 방식 수정

- createRoomItem을 하는 RoomItemFactory 작성
- MessageRenderer.prototype.renderRoomItem 에서 RoomItemFactory 이용 하여 RoomItem 생성
- 불필요해진 message-public 이벤트 관련한 함수 제거
- loadRoomInfo 이벤트 발생을 제어할 agoLoadMessageIsExcuted 속성 추가
- message-get-in-room 의 이벤트 발생에 의해 방에 이전 메시지들을 불러오는 loadMessage 함수 제어를 위해 agoLoadMessageTargetRoom 속성 추가
- loadMessage 의 반환을 Promise로 변경 하고 작업을 비동기처리로 변경
- loadMessage 가 Promise로 변경됨에 따라 상태 제어함수인 agoLoadMessageIsResolve, agoLoadMessageIsReject 를 추가

### bot_socket

- 모든 이벤트에 대해 로그만 찍도록 변경