### PR TITLE
룸 버튼 클릭시 참여자 목록이 쌓이는 현상 수정

### DIFF
--- a/app/services/MemberListView.js
+++ b/app/services/MemberListView.js
@@ -41,4 +41,11 @@ MemberListView.prototype.getCount = function () {
   return this.view.childElementCount;
 };
 
+MemberListView.prototype.clearRow = function () {
+  // member list
+  let mems = this.view;
+  mems.innerHTML = '';
+  console.log(mems);
+};
+
 module.exports = MemberListView;

--- a/app/services/RoomActionBar.js
+++ b/app/services/RoomActionBar.js
@@ -25,6 +25,7 @@ RoomActionBar.prototype.InitializeActionBar = function () {
     manager.toggleClass(self.ActionBar,'unfold');
     manager.toggleClass(event.srcElement,'unfold');
   };
+  this.MemberListView.clearRow();
 };
 RoomActionBar.prototype.removeAction = function () {
   this.ActionBar.removeEventListener(this.EVENT,this.ActionBarEventHandller);
@@ -32,6 +33,5 @@ RoomActionBar.prototype.removeAction = function () {
 };
 RoomActionBar.prototype.ActionBarEventHandller = function (event) {
   const view = event.srcElement;
-
 };
 module.exports = RoomActionBar;

--- a/app/services/message_renderer.js
+++ b/app/services/message_renderer.js
@@ -24,7 +24,8 @@ MessageRenderer.prototype.loadRoomList = function(id, socket) {
   const roomList = document.getElementById(id);
   const joinRoomList = socket.user.JoinRoomList;
   const self = this;
-  this.RoomActionBar.InitializeActionBar();
+  const roomActionBar = this.RoomActionBar;
+  roomActionBar.InitializeActionBar();
   /**
    * @description This condition explains that there is no need to reload.
    */
@@ -73,6 +74,7 @@ MessageRenderer.prototype.loadParticipant = function (socket, room) {
     if(!room){
       return reject(new Error('loadParticipant need room parameter'));
     }
+    this.RoomActionBar.MemberListView.clearRow();
     room.Participant.forEach((participant)=>{
       console.log(participant);
       const memberView = new MemberView(this.document,participant.nickName,socket.args.picture);


### PR DESCRIPTION
방 버튼 클릭시 이전에 추가 된 참여자 현황이 초기화 되지 않아 쌓이는 현상 수정
### message_renderer

- message_renderer.js line 77 loadParticipant()  this.RoomActionBar.MemberListView.clearRow();  추가

### MemberListView

- line 44 clearRow() 추가 : 방 버튼 click 할 때 마다 Member List view innerHTML 초기화

