### PR TITLE
MessageFactory.js, message_renderer.js, socket.js, main.js 수정

### DIFF
--- a/app/services/MessageFactory.js
+++ b/app/services/MessageFactory.js
@@ -1,12 +1,12 @@
 'use strict';
 
-function MessageFactory() {
+function MessageFactory(locale) {
   if(!(this instanceof MessageFactory)){
     throw new TypeError('MessageFactory must be created with new keyword');
   }
   this.moment = require('moment');
   this.utcOffset = this.moment().utcOffset();
-  this.moment.locale('ko');
+  this.moment.locale(locale);
 }
 
 MessageFactory.prototype.createMessageRow = function (document) {

--- a/app/services/message_renderer.js
+++ b/app/services/message_renderer.js
@@ -1,6 +1,6 @@
 'use strict';
 
-function MessageRenderer(document,window) {
+function MessageRenderer(document,window,locale) {
   if(!(this instanceof MessageRenderer)){
     throw new TypeError('MessageRenderer must be created with new keyword');
   }
@@ -10,8 +10,9 @@ function MessageRenderer(document,window) {
   const MessageListView = require('../services/MessageListView');
   this.document = document;
   this.window = window;
+  this.locale = locale;
   this.messageType = require('../services/message_type');
-  this.MessageFactory = new MessageFactory();
+  this.MessageFactory = new MessageFactory(locale);
   this.RoomItemFactory = new RoomItemFactory(document);
   this.RoomActionBar = new RoomActionBar(document);
   this.MessageListView = new MessageListView(document);
@@ -167,7 +168,7 @@ MessageRenderer.prototype.sendPrivacyMessage = function(socket){
   const textBox = this.document.getElementById('messageInput');
   const moment = require('moment');
   const utcOffset = moment().utcOffset();
-  moment.locale('ko');
+  moment.locale(this.locale);
   // textbox 공백 체크 후에 메세지 전송 및 render 처리
   if(textBox.value !== '') {
     let msg = textBox.value;

--- a/app/services/socket.js
+++ b/app/services/socket.js
@@ -6,14 +6,16 @@
   const MessageRenderer = require('./app/services/message_renderer');
   const Channel = require('./app/services/channel');
   const channel = new Channel();
-  const renderer = new MessageRenderer(document,window);
+  let renderer;
   const ipcRenderer = electron.ipcRenderer;
   let token = undefined;
   let defaultSocket;
   let botSocket;
-  ipcRenderer.on('connect',(event,args)=>{
+  ipcRenderer.on('connect',(event,args,locale)=>{
+    console.log(locale);
     console.log('receive event from ipcMain');
-    defaultSocket = connectToDefault(args,token,channel.DEVELOPMENT_HOST(),renderer);
-    botSocket = connectToBot(args,token,channel.DEVELOPMENT_BOT_CHANNEL(),renderer);
+    renderer = new MessageRenderer(document,window,locale);
+    defaultSocket = connectToDefault(args, token, channel.DEVELOPMENT_HOST(), renderer);
+    botSocket = connectToBot(args, token, channel.DEVELOPMENT_BOT_CHANNEL(), renderer);
   });
 })();

--- a/main.js
+++ b/main.js
@@ -9,6 +9,7 @@ const FBManager = require('./main/fbmanager');
 const fbManager = new FBManager(app,axios,path,fs,FB);
 
 let win;
+let locale;
 
 function createAuthWindow() {
   fbManager.login(win,BrowserWindow);
@@ -16,7 +17,7 @@ function createAuthWindow() {
 
 function createLoginWindow() {
   const {width,height}= electron.screen.getPrimaryDisplay().workAreaSize;
-
+  locale = app.getLocale();
   /**
    * @TODO mobile, desktop 별 modal 화면 크기 조정 별도 로직 필요
    */
@@ -105,7 +106,8 @@ ipcMain.on('changeView',(event,id)=>{
   win.setResizable(true);
   win.setFullScreenable(true);
   win.webContents.on('did-finish-load',()=>{
-    win.webContents.send('connect',id);
+    console.log(locale);
+    win.webContents.send('connect',id,locale);
   });
 });
 


### PR DESCRIPTION


### app/services/MessageFactory.js,
- 생성시 locale 파라미터로 받아서 해당 locale로 moment locale 세팅하도록 수정
### app/services/message_renderer.js,
- 생성시 locale 파라미터로 받도록 추가하고 MessageFactory 를 생성할 때 locale 을 전달하도록 수정
- sendPrivacyMessage 에서 moment locale을 앞에서 세팅한 locale로 세팅
### app/services/socket.js
- ipcMain 에서 전달한 locale 파라미터 받은 후 renderer 생성하도록 수정
### main.js
- app.getLocale()은 app의 ready 이벤트를 받은 후 정상동작 가능. 그 이전은 default인 en-us 만 리턴하므로 ready 이후 createLoginWindow 에서 세팅
- changeView 이벤트 콜백안의 did-finish-load 이벤트 콜백에서 index.html에서 리슨하고 있는 connect 이벤트로 locale 파라미터 추가하여 전달