### PR TITLE
MessageArea 애니메이션 추가 후 메시지 영역 높이 재계산 하도록 추가

### DIFF
--- a/app/css/RoomActionBar.css
+++ b/app/css/RoomActionBar.css
@@ -8,7 +8,7 @@
     height: 0;
     visibility: visible;
     border-radius: 0%;
-    transition: height 1s;
+    transition: height 0.8s;
 }
 .RoomActionBar.unfold{
     height: 120px;
@@ -26,7 +26,7 @@
     background:#5168d0;
     border-radius: 0 0 25px 25px;
     box-shadow: 0 0 1px 1px #555555;
-    transition: background 1s, border-radius 0.5s,box-shadow 0.5s, top 1s;
+    transition: background 1s, border-radius 0.8s,box-shadow 0.5s, top 0.8s;
 }
 .RoomActionBar-fold-button.unfold{
     z-index: 5;

--- a/app/css/chat.css
+++ b/app/css/chat.css
@@ -210,10 +210,11 @@ body, html {
     top:0;
     height: calc(100% - 60px); /*message-area 내에서 메시지를 제외한 영역 부분 빼줘야함*/
     background: darkslategray;
-    transition: top 1s;
+    transition: top 0.8s, height 0.8s;
 }
 .message-area.unfold{
     top:120px;
+    height: calc(100% - 180px);
 }
 
 .my-message-block {
@@ -407,6 +408,10 @@ body, html {
     width: 100%;
     height: 60px;
     background: #424242;
+    transition: margin-top 0.8s;
+}
+.input-wrapper.unfold{
+    margin-top: 120px;
 }
 .message-input{
     resize: none;

--- a/app/services/MessageListView.js
+++ b/app/services/MessageListView.js
@@ -24,5 +24,10 @@ MessageListView.prototype.RemoveAllMessages = function () {
     this.view.removeChild(this.view.firstChild);
   }
 };
-
+MessageListView.prototype.scrollToBottom = function () {
+  this.view.scrollTop = this.view.scrollHeight;
+};
+MessageListView.prototype.scrollToTop = function () {
+  this.view.scrollTop = this.view.scrollHeight-this.view.scrollHeight;
+};
 module.exports = MessageListView;

--- a/app/services/RoomActionBar.js
+++ b/app/services/RoomActionBar.js
@@ -5,6 +5,7 @@ function RoomActionBar(document) {
     throw new TypeError('RoomActionBar must be created with new keyword');
   }
   const MemberListView = require('../services/MemberListView');
+  this.document = document;
   this.ActionBar = document.getElementById('RoomActionBar');
   this.MemberListView = new MemberListView(document);
   this.RoomActionBarFoldButton = document.getElementById('RoomActionBar-fold-button');
@@ -14,6 +15,8 @@ function RoomActionBar(document) {
 
 RoomActionBar.prototype.InitializeActionBar = function (socket,MessageListView) {
   const self = this;
+  const inputWrapper = this.document.querySelector('.input-wrapper');
+  console.log(inputWrapper);
   this.removeAction().addEventListener(this.EVENT,this.ActionBarEventHandller);
   removeEventHandler().addEventListener(this.EVENT,ButtonClickEventHandler.bind(null,MessageListView));
   self.ActionLeaveRoomButton.addEventListener(self.EVENT, removeRoomInfo);
@@ -27,6 +30,8 @@ RoomActionBar.prototype.InitializeActionBar = function (socket,MessageListView) 
     manager.toggleClass(self.ActionBar,'unfold');
     manager.toggleClass(event.srcElement,'unfold');
     manager.toggleClass(MessageListView.view,'unfold');
+    manager.toggleClass(inputWrapper,'unfold');
+
   };
   function removeRoomInfo(){
     const selectRoom = document.getElementsByClassName('room-item selected');

--- a/app/services/message_renderer.js
+++ b/app/services/message_renderer.js
@@ -46,25 +46,6 @@ MessageRenderer.prototype.loadRoomInfo = function (socket, event) {
   const selectedRoom = event.srcElement.parentNode;
   socket.emit('message-get-in-room', {token:socket.access_token,room_id:selectedRoom.id});
 };
-MessageRenderer.prototype.loadMessage = function(socket,room){
-  return new Promise((resolve,reject)=>{
-    if(room.messages.length === 0){
-      return reject({MessageRenderer:this,roomId:room._id});
-    }
-    if(this.agoLoadMessageTargetRoom === room.messages[0].roomId) {
-      return reject({MessageRenderer:this,roomId:room.messages[0].roomId});
-    }
-    console.log('load Message : '+this.agoLoadMessageTargetRoom+'||'+room.messages[0].roomId);
-
-    for (let i = 0; i < room.messages.length; i++) {
-      let msg = room.messages[i];
-      socket.user._id === msg.author._id? this.renderMessage(msg, this.messageType.MY_MESSAGE,socket.args.picture):this.renderMessage(msg, this.messageType.ANOTHER_MESSAGE);
-    }
-
-    return resolve({MessageRenderer:this,roomId:room._id});
-  });
-};
-
 
 MessageRenderer.prototype.loadMessageCancelablePromise = function(socket,room){
   let isExcuted = false;
@@ -223,20 +204,9 @@ MessageRenderer.prototype.renderMessage = function (message, type, image) {
         break;
     }
 
-    self.scrollToBottom('message-area');
+    this.MessageListView.scrollToBottom();
     return myMessageRow;
 };
 
-// Mesaage view scroll to bottom after receive message.
-MessageRenderer.prototype.scrollToBottom = function (elementId) {
-  const messageArea = this.document.getElementById(elementId);
-  messageArea.scrollTop = messageArea.scrollHeight;
-};
-
-
-MessageRenderer.prototype.scrollToTop = function (elementId) {
-  const messageArea = this.document.getElementById(elementId);
-  messageArea.scrollTop = messageArea.scrollHeight-messageArea.scrollHeight;
-};
 
 module.exports = MessageRenderer;


### PR DESCRIPTION
### app/css/RoomActionBar.css
- height 변경
### app/css/chat.css
- .message-area.unfold 일때 height 재계산
- .input-wrapper.unfold 추가. margin-top 애니메이션
### app/services/RoomActionBar.js
- input-wrapper 쿼리셀렉터로 가지고오고 toggle하는 부분 추가
### app/services/message_renderer.js
- scrollToBottom, scrollToTop 함수 MessageListView 로 이동
- scrollToBottom 호출을 MessageListView 객체로 호출
- loadMessage 함수 삭제 -> loadMessageCancelablePromise 로 변경했었음 이전 커밋에서